### PR TITLE
ensure the thread shuts down

### DIFF
--- a/src/main/java/com/github/hindol/commons/file/DirectoryWatcher.java
+++ b/src/main/java/com/github/hindol/commons/file/DirectoryWatcher.java
@@ -63,6 +63,7 @@ public class DirectoryWatcher implements Runnable, Service {
     public void stop() {
         mWatcherTask.cancel(true);
         mWatcherTask = null;
+        EXECUTOR.shutdown();
     }
 
     @Override
@@ -100,11 +101,8 @@ public class DirectoryWatcher implements Runnable, Service {
                 break;
             }
 
-            WatchKey key;
-            try {
-                key = watchService.take();
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
+            WatchKey key = watchService.poll();
+            if(key == null) {
                 continue;
             }
 
@@ -137,6 +135,7 @@ public class DirectoryWatcher implements Runnable, Service {
                 }
             }
         }
+        LOGGER.trace("exiting DirectoryWatcher.run");
     }
 
     public interface Listener {


### PR DESCRIPTION
Currently the thread does not shut down when the DirectoryWatcher is stopped. These changes correct that. Do note that with these changes one will not be able to start a DirectoryWatcher that has been stopped. If that is necessary, then the EXECUTOR should be made not final and should be instantiated inside start.